### PR TITLE
feat: collapse mobile navbar when document or any menu link is clicked

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import '../styles/Navbar.css';
+import $ from 'jquery';
 import logo from '../assets/eden-logo.svg';
 
 function Navbar() {
@@ -28,7 +29,7 @@ function Navbar() {
       <div className="collapse navbar-collapse" id="navbarSupportedContent">
         <ul className="navbar-nav ml-auto mr-5 pr-3">
           <li className="nav-item p-2">
-            <a className="nav-link " href="#platform">
+            <a className="nav-link" href="#platform">
               Our Platform
             </a>
           </li>
@@ -47,5 +48,11 @@ function Navbar() {
     </nav>
   );
 }
+
+function collapseMobileNav() {
+  $('.navbar-collapse').collapse('hide');
+}
+
+document.addEventListener('click', collapseMobileNav);
 
 export default Navbar;


### PR DESCRIPTION
Issue #37 

Feature:
As a user on a small screen, when I use the mobile navbar, the navbar collapses when I select a menu item or click anywhere else on the page.

The function collapseMobileNav was written in Navbar.js and used as a callback function in a click event listener on the document.

An extra space was also removed from line 31 in Navbar.js.